### PR TITLE
Fixes for the install-to-internal-storage script

### DIFF
--- a/bin/install-to-internal-storage
+++ b/bin/install-to-internal-storage
@@ -2,7 +2,7 @@
 
 set -e
 
-sudo apt install vboot-kernel-utils cgpt -y
+sudo apt install vboot-kernel-utils cgpt curl rsync -y
 
 echo "What drive would you like to install to? (e.g. /dev/mmcblk0)"
 read -r USB

--- a/bin/install-to-internal-storage
+++ b/bin/install-to-internal-storage
@@ -36,7 +36,7 @@ sudo rsync -a --info=progress2  / /mnt --exclude proc --exclude sys --exclude de
 echo "Writing storage, will take a few minutes"
 sync
 
-bash <(curl -s https://raw.githubusercontent.com/cb-linux/kernel/main/kernel.emmc.flags.sh) > cmdline
+bash <(curl -s https://raw.githubusercontent.com/cb-linux/kernel/673e848836ff164d2ff51dae1402c749cd6d3505/kernel.emmc.flags.sh) > cmdline
 
 # Get the bzImage
 sudo dd if=/dev/sda1 of=bzImage


### PR DESCRIPTION
The awesomeness of Linux > no sound on my Chromebook, so I went ahead and ran the install-to-internal-storage script to get Debian 11 installed on my Chromebook (ASUS C425). There were a couple of things I needed to fix in the script to get it to work:

- The script used rsync and curl, which were not installed, so I added these to the `apt get` statement at the beginning of the script where the prereqs are obtained.
- The path to the `kernel.emmc.flags.sh` script executed via a curl hook returned a 404 error which resulted in an enigmatic command not found error due to (I think) non-breaking whitespace characters from the html. I found the working path and updated the script.

I hope this helps others! I really appreciate the work you did to create Breath.