### PR TITLE
Autoload vfat for Ubuntu

### DIFF
--- a/utils/distros/ubuntu.sh
+++ b/utils/distros/ubuntu.sh
@@ -25,6 +25,9 @@ EOF
     sudo tee -a ${MNT}/etc/modules > /dev/null <<EOT
     iwlmvm
     uvcvideo
+    nls_iso8859-1
+    nls_cp437
+    vfat
 EOT
 
     # Desktop installation fails without this


### PR DESCRIPTION
vfat, exFAT, FAT32, FAT16 all require vfat to be loaded