### PR TITLE
Make purge of pulseaudio automatic

### DIFF
--- a/bin/sof-setup-audio
+++ b/bin/sof-setup-audio
@@ -15,8 +15,8 @@ case $SOUNDCARD in # TODO: add realtek support for octopus
 esac
 
 # Remove PulseAudio
-sudo apt purge pulseaudio
-sudo apt purge pulseaudio*
+sudo apt purge -y pulseaudio
+sudo apt purge -y pulseaudio*
 sudo apt install -y apulse alsa-*
 sudo apt install -y firmware-sof-signed || sudo apt-get -o Dpkg::Options::="--force-overwrite" install firmware-sof-signed
 


### PR DESCRIPTION
No reason not to force the 'Y' since this has to happen to setup the audio.  Not forcing it requires the user to unnecessarily have to hit the  [Enter] to continue the setup.