### PR TITLE
Support building on Arch-based systems

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,7 @@ source utils/functions.sh # Functions
 source utils/bootstrap.sh # Bootstrap Function
 source utils/partition.sh # USB Partitioning
 source utils/extract.sh   # Extract Rootfs
+source utils/system.sh    # Host OS Abstraction
 
 # Exit if the user did not specify the desktop
 [[ -n "$1" ]] || { printerr "No desktop specified"; exit; }
@@ -39,6 +40,9 @@ source utils/distros/${DISTRO}.sh
 
 # Exit on errors
 set -e
+
+# Determine host system
+whichOperatingSystem
 
 # Many much importance
 sudo apt install -y toilet

--- a/setup.sh
+++ b/setup.sh
@@ -45,7 +45,7 @@ set -e
 whichOperatingSystem
 
 # Many much importance
-sudo apt install -y toilet
+installDependencies toilet
 
 # Print 15 lines to "fake" clear the screen
 # shellcheck disable=SC2034

--- a/utils/bootstrap.sh
+++ b/utils/bootstrap.sh
@@ -15,7 +15,8 @@ function bootstrapFiles {
 
   # If the ChromeOS firmware utility doesn't exist, install it and other packages
   printq "Installing Dependencies"
-  sudo apt install -y vboot-kernel-utils arch-install-scripts git wget cgpt $FW_PACKAGE
+  # sudo apt install -y vboot-kernel-utils arch-install-scripts git wget cgpt $FW_PACKAGE
+  installDependencies vboot-kernel-utils arch-install-scripts git wget cgpt $FW_PACKAGE
 
 
   # Download the kernel bzImage and the kernel modules (wget)

--- a/utils/bootstrap.sh
+++ b/utils/bootstrap.sh
@@ -15,7 +15,6 @@ function bootstrapFiles {
 
   # If the ChromeOS firmware utility doesn't exist, install it and other packages
   printq "Installing Dependencies"
-  # sudo apt install -y vboot-kernel-utils arch-install-scripts git wget cgpt $FW_PACKAGE
   installDependencies vboot-kernel-utils arch-install-scripts git wget cgpt $FW_PACKAGE
 
 
@@ -66,7 +65,7 @@ function bootstrapFiles {
 
   debian)
       # Debian uses debootstrap rather than extracting a prebuilt rootfs
-      sudo apt install debootstrap -y
+      installDependencies debootstrap
       ;;
 
 

--- a/utils/distros/arch.sh
+++ b/utils/distros/arch.sh
@@ -55,5 +55,5 @@ EOT
 EOT
 
     # Install nmcli for wifi
-    sudo arch-chroot $MNT bash -c "pacman -S networkmanager"
+    sudo arch-chroot $MNT bash -c "pacman -S --noconfirm networkmanager"
 }

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -60,3 +60,12 @@ function unmountUSB {
 function runChrootCommand {
   sudo chroot $MNT /bin/sh -c "$1"
 }
+
+# Function for running command without root priveleges
+# TODO: FIX root user issues(whoami reports as root)
+function runUnRootedCommand () {
+    su $(whoami) -c bash <<EOF
+    whoami
+    $*
+EOF
+} 

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -60,12 +60,3 @@ function unmountUSB {
 function runChrootCommand {
   sudo chroot $MNT /bin/sh -c "$1"
 }
-
-# Function for running command without root priveleges
-# TODO: FIX root user issues(whoami reports as root)
-function runUnRootedCommand () {
-    su $(whoami) -c bash <<EOF
-    whoami
-    $*
-EOF
-} 

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -29,7 +29,7 @@ function whichOperatingSystem {
 
 }
 
-# INstall dependencies based on distro
+# Install dependencies based on distro
 function installDependencies () {
 
     # TODO: Implement installDependencies
@@ -45,25 +45,20 @@ function installDependencies () {
 
     Arch)
         # Install dependencies on a Arch host OS
+        if [[ -f /usr/bin/yay ]]; then
+            # Install dependencies if yay is found
+            yay -S --noconfirm $*
 
-        # Install yay
-        installYay
-
-        yay -Syy --noconfirm $*
+        else
+            # Install yay if not on host OS
+            printq "Installing yay..."
+            git clone https://aur.archlinux.org/yay.git && cd yay
+            runUnRootedCommand makepkg -si
+            cd .. && rm -rf yay
+            yay -Syyu --noconfirm
+        fi
         ;;
 
     esac
-
-}
-
-# Install yay aur helper if not on system
-function installYay {
-    if [[ -f /usr/bin/yay ]]; then
-        echo "Yay already installed, moving on..."
-
-    else
-        git clone https://aur.archlinux.org/yay.git
-        cd yay && makepkg -si
-    fi
 
 }

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -16,6 +16,10 @@ function whichOperatingSystem {
         elif [[ -f /etc/arch-release ]]; then
             DIST="Arch"
 
+	# Fedora
+        elif [[ -f /etc/fedora-release ]]; then
+	    DIST="Fedora"
+
         # Other
         else
             printerr "This distribution is not supported, exiting!"
@@ -32,19 +36,18 @@ function whichOperatingSystem {
 # Install dependencies based on distro
 function installDependencies () {
 
-    # TODO: Implement installDependencies
-    # NOTE: Use "$*" to call all function arguments
+    # NOTE: "$*" is used to call all function arguments
 
     # Download dependencies based on distribution
     case $DIST in
 
     Debian)
-        # Install dependencies on a Debian host OS
+        # Install dependencies on a Debian host system
         sudo apt install -y $*
         ;;
 
     Arch)
-        # Install dependencies on a Arch host OS
+        # Install dependencies on a Arch host system
         if [[ -f /usr/bin/yay ]]; then
             # Install dependencies if yay is found
             for var in "$@"
@@ -71,6 +74,11 @@ function installDependencies () {
             exit
         fi
         ;;
+
+    Fedora)
+    # Install dependencies on a Fedora host system
+    sudo dnf install $* --assumeyes
+    ;;
 
     esac
 

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -50,12 +50,9 @@ function installDependencies () {
             yay -S --noconfirm $*
 
         else
-            # Install yay if not on host OS
-            printq "Installing yay..."
-            git clone https://aur.archlinux.org/yay.git && cd yay
-            runUnRootedCommand makepkg -si
-            cd .. && rm -rf yay
-            yay -Syyu --noconfirm
+            # Yay not istalled, exiy
+            printerr "Please install yay(https://aur.archlinux.org/yay.git) to continue installation, exiting!"
+            exit
         fi
         ;;
 

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Determine host system 
 function whichOperatingSystem {
 
     OS=$(uname -s)
@@ -28,13 +29,14 @@ function whichOperatingSystem {
 
 }
 
+# INstall dependencies based on distro
 function installDependencies () {
 
     # TODO: Implement installDependencies
     # NOTE: Use "$*" to call all function arguments
     
     # Download dependencies based on distribution
-    case $DIST in
+    case  $DIST in
 
     Debian)
         # Install dependencies on a Debian host OS
@@ -43,10 +45,25 @@ function installDependencies () {
 
     Arch)
         # Install dependencies on a Arch host OS
-        # TODO: Implement arch install
-        exit
+
+        # Install yay
+        installYay
+
+        yay -Syy --noconfirm $*
         ;;
 
     esac
+
+}
+
+# Install yay aur helper if not on system
+function installYay {
+    if [[ -f /usr/bin/yay ]]; then
+        echo "Yay already installed, moving on..."
+
+    else
+        git clone https://aur.archlinux.org/yay.git
+        cd yay && makepkg -si
+    fi
 
 }

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -52,7 +52,7 @@ function installDependencies () {
             # Install dependencies if yay is found
             for var in "$@"
             do
-                # replace package names relevant to distro
+                # Replace package names relevant to distro
                 case $var in
 
                     # vboot-utils
@@ -77,7 +77,24 @@ function installDependencies () {
 
     Fedora)
     # Install dependencies on a Fedora host system
-    sudo dnf install $* --assumeyes
+    for var in "$@"
+    do
+        # Replace package names relevant to distro
+        case $var in
+
+            # vboot-utils
+            vboot-kernel-utilities)
+                var=vboot-utils;
+                ;;
+
+            # cgpt
+            cgpt)
+               unset var; # Included in vboot-utils
+               ;;
+        
+        esac
+        sudo dnf install $* --assumeyes
+    done
     ;;
 
     esac

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -34,9 +34,9 @@ function installDependencies () {
 
     # TODO: Implement installDependencies
     # NOTE: Use "$*" to call all function arguments
-    
+
     # Download dependencies based on distribution
-    case  $DIST in
+    case $DIST in
 
     Debian)
         # Install dependencies on a Debian host OS
@@ -47,10 +47,21 @@ function installDependencies () {
         # Install dependencies on a Arch host OS
         if [[ -f /usr/bin/yay ]]; then
             # Install dependencies if yay is found
-            yay -S --noconfirm $*
+            for var in "$@"
+            do
+                # replace package names relevant to distro
+                case $var in
 
+                    # vboot-utils
+                    # TODO: Yay fails to install because of permission error(128)
+                    vboot-kernel-utils)
+                        var=vboot-utils;
+
+                esac
+                yay -S --noconfirm $var
+            done
         else
-            # Yay not istalled, exiy
+            # Yay not istalled, exit
             printerr "Please install yay(https://aur.archlinux.org/yay.git) to continue installation, exiting!"
             exit
         fi

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+function whichOperatingSystem {
+
+    # TODO: Finish work here!
+
+    OS=$(uname -s) # Determine operating system
+    
+    if [[ $OS == Linux ]]; then
+        
+        # Debian
+        if [[ -f /etc/debian_version ]]; then
+            DIST="Debian"
+        
+        # Arch
+        elif [[ -f /etc/arch-release ]]; then
+            DIST="Arch"
+
+        # Other
+        else
+            printerr "This distribution is not supported, exiting!"
+            exit
+        fi
+
+    else
+        printerr "$OS is not supported, exiting!"
+        exit
+    fi
+
+}
+
+function installDependencies () {
+
+    # TODO: Implement installDependencies
+    # NOTE: Use "$*" to call all arguments
+    exit
+
+}

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -2,10 +2,9 @@
 
 function whichOperatingSystem {
 
-    # TODO: Finish work here!
+    OS=$(uname -s)
 
-    OS=$(uname -s) # Determine operating system
-    
+    # Determine operating system and distro
     if [[ $OS == Linux ]]; then
         
         # Debian
@@ -32,7 +31,22 @@ function whichOperatingSystem {
 function installDependencies () {
 
     # TODO: Implement installDependencies
-    # NOTE: Use "$*" to call all arguments
-    exit
+    # NOTE: Use "$*" to call all function arguments
+    
+    # Download dependencies based on distribution
+    case $DIST in
+
+    Debian)
+        # Install dependencies on a Debian host OS
+        sudo apt install -y $*
+        ;;
+
+    Arch)
+        # Install dependencies on a Arch host OS
+        # TODO: Implement arch install
+        exit
+        ;;
+
+    esac
 
 }

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -53,9 +53,14 @@ function installDependencies () {
                 case $var in
 
                     # vboot-utils
-                    # TODO: Yay fails to install because of permission error(128)
                     vboot-kernel-utils)
                         var=vboot-utils;
+                        ;;
+
+                    # cgpt
+                    cgpt)
+                        unset var; # Included in vboot-utils
+                        ;;
 
                 esac
                 yay -S --noconfirm $var

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -76,26 +76,31 @@ function installDependencies () {
         ;;
 
     Fedora)
-    # Install dependencies on a Fedora host system
-    for var in "$@"
-    do
-        # Replace package names relevant to distro
-        case $var in
+        # Install dependencies on a Fedora host system
+        for var in "$@"
+        do
+            # Replace package names relevant to distro
+            case $var in
 
-            # vboot-utils
-            vboot-kernel-utilities)
-                var=vboot-utils;
-                ;;
+                # vboot-utils
+                vboot-kernel-utils)
+                    var=vboot-utils;
+                    ;;
 
-            # cgpt
-            cgpt)
-               unset var; # Included in vboot-utils
-               ;;
+                # cgpt
+                cgpt)
+                    unset var; # Included in vboot-utils
+                    ;;
         
-        esac
-        sudo dnf install $* --assumeyes
-    done
-    ;;
+            esac
+            # dnf doesn't like $FW_PACKAGE, do nothing on null $var
+            if [[ -z "$var" ]]; then
+                :
+            else
+                sudo dnf install $var --assumeyes
+            fi
+        done
+        ;;
 
     esac
 


### PR DESCRIPTION
### Status
- [x] Ready

### Summary
The current state of the project is that it can only be used on Debian-based distros. Adding an OS abstraction and proper support for distributions such as Arch Linux will greatly increase the reach of the project. On top of this, further distro's can be easily supported afterwards, possibly MacOS as well if needed.

### Tasks
- [x] Arch support
- [x] Fedora support
- [x] Per-Distro dependency abstraction
- [x] Update docs
- [x] Initial approval