### PR TITLE
Autoprompt root passwd

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -41,6 +41,10 @@ source utils/distros/${DISTRO}.sh
 # Exit on errors
 set -e
 
+# Get root passwd
+# NOTE: Used to allow for less user intervention during install
+getPassword
+
 # Many much importance
 installDependencies toilet
 

--- a/setup.sh
+++ b/setup.sh
@@ -41,10 +41,6 @@ source utils/distros/${DISTRO}.sh
 # Exit on errors
 set -e
 
-# Get root passwd
-# NOTE: Used to allow for less user intervention during install
-getPassword
-
 # Many much importance
 installDependencies toilet
 

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -60,3 +60,30 @@ function unmountUSB {
 function runChrootCommand {
   sudo chroot $MNT /bin/sh -c "$1"
 }
+
+# Function for storing passwd as temporary variable $PASSWD
+function getPassword {
+
+    # Define DIST if not defined
+    # NOTE: Although this is if statement is being reused from
+    # system.sh, in the future if any functions are moved around
+    # it will be handy to have this check in both places to prevent
+    # silent failure to save passwd.
+    if [[ -z $DIST ]]; then
+        whichOperatingSystem
+    fi
+
+    case $DIST in
+
+        # The yay aur helper cannot be run with sudo priveleges,
+        # so instead of reading passwd, we enable '--sudo-loop'.
+        Arch)
+            yay -Syyu --save --sudoloop --noconfirm
+            ;;
+
+        # Every other distro can have $PASSWD silently read
+        *)
+            read -s -p "[sudo] password for $(whoami): " PASSWD
+            ;;
+    esac
+}

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -60,30 +60,3 @@ function unmountUSB {
 function runChrootCommand {
   echo $PASSWD || sudo -S chroot $MNT /bin/sh -c "$1"
 }
-
-# Function for storing passwd as temporary variable $PASSWD
-function getPassword {
-
-    # Define DIST if not defined
-    # NOTE: Although this is if statement is being reused from
-    # system.sh, in the future if any functions are moved around
-    # it will be handy to have this check in both places to prevent
-    # silent failure to save passwd.
-    if [[ -z $DIST ]]; then
-        whichOperatingSystem
-    fi
-
-    case $DIST in
-
-        # The yay aur helper cannot be run with sudo priveleges,
-        # so instead of reading passwd, we enable '--sudo-loop'.
-        Arch)
-            yay -Syyu --save --sudoloop --noconfirm
-            ;;
-
-        # Every other distro can have $PASSWD silently read
-        *)
-            read -s -p "[sudo] password for $(whoami): " PASSWD
-            ;;
-    esac
-}

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -58,5 +58,5 @@ function unmountUSB {
 
 # Function for running a command in the chroot
 function runChrootCommand {
-  echo $PASSWD || sudo -S chroot $MNT /bin/sh -c "$1"
+  read -s $PASSWD || sudo -S chroot $MNT /bin/sh -c "$1"
 }

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -58,7 +58,7 @@ function unmountUSB {
 
 # Function for running a command in the chroot
 function runChrootCommand {
-  sudo chroot $MNT /bin/sh -c "$1"
+  echo $PASSWD || sudo -S chroot $MNT /bin/sh -c "$1"
 }
 
 # Function for storing passwd as temporary variable $PASSWD

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -53,7 +53,7 @@ function waitForUSB {
 # Function to unmount all partitions on the USB and /mnt
 # This command may fail, so use || true
 function unmountUSB {
-  (sudo umount ${USB}*; sudo umount $MNT; sudo umount /media/*/*) || true
+  (read -s $PASSWD || sudo -S umount ${USB}*; sudo umount $MNT; sudo umount /media/*/*) || true
 }
 
 # Function for running a command in the chroot

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -39,7 +39,7 @@ function whichOperatingSystem {
 }
 
 # Store root passwd in $PASSWD
-function getPassword {   
+function getPassword {  
     read -s -p "[sudo] password for $(whoami): " PASSWD
 }
 
@@ -58,8 +58,10 @@ function updateSystemPackages () {
         Arch)
             # Upgrade && update arch-based distro's
             # NOTE: Due to yay not being able to run as root,
-            # '--save --sudoloop' is in essence bypassing 
-            # getPassword.
+            # '--save --sudoloop' is in essence doing what getPassword
+            # is doing for chrooted commands
+            printq "Yay requires a root password as well to run."
+            printq "You will only be asked once throughout this install."
             yay -Syy --save --sudoloop --noconfirm
             ;;
 
@@ -82,13 +84,9 @@ function installDependencies () {
     fi
 
     # Cache root passwd for the entirety of the installation
-    # NOTE: Arch does not make use of $PASSWD
-    # NOTE: $COUNTER exists to prevent getPassword or updateSystemPackages
-    # from running twice
-    if [[ -z $PASSWD && $DIST != "Arch" && -z $COUNTER ]]; then
-        getPassword && updateSystemPackages && set COUNTER=1
-    else
-        updateSystemPackages && COUNTER=1
+    if [[ -z $PASSWD ]]; then
+        getPassword
+        updateSystemPackages
     fi
 
     echo "Installing $*"

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -57,11 +57,6 @@ function updateSystemPackages () {
 
         Arch)
             # Upgrade && update arch-based distro's
-            # NOTE: Due to yay not being able to run as root,
-            # '--save --sudoloop' is in essence doing what getPassword
-            # is doing for chrooted commands
-            printq "Yay requires a root password as well to run."
-            printq "You will only be asked once throughout this install."
             yay -Syy --save --sudoloop --noconfirm
             ;;
 
@@ -86,7 +81,6 @@ function installDependencies () {
     # Cache root passwd for the entirety of the installation
     if [[ -z $PASSWD ]]; then
         getPassword
-        updateSystemPackages
     fi
 
     echo "Installing $*"
@@ -97,7 +91,7 @@ function installDependencies () {
     Debian)
         # Install dependencies on a Debian host system
         read -s $PASSWD || sudo -S apt install -y "$@"
-        ;;
+        ;; 
 
     Arch)
         # Install dependencies on a Arch host system
@@ -124,7 +118,7 @@ function installDependencies () {
                         ;;
 
                 esac
-                yay -S --noconfirm $var
+                yay -S --save --sudoloop --noconfirm $var
             done
         else
             # Yay not istalled, exit

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -38,6 +38,51 @@ function whichOperatingSystem {
 
 }
 
+# Store root passwd in $PASSWD
+function getPassword {
+
+    # TODO: Polish and move updates away to updateSystemPackages
+
+    case $DIST in
+
+        # The yay aur helper cannot be run with sudo priveleges,
+        # so instead of reading passwd, we enable '--sudo-loop'.
+        Arch)
+            yay -Syyu --save --sudoloop --noconfirm
+            ;;
+
+        # Every other distro can have $PASSWD silently read
+        *)
+            read -s -p "[sudo] password for $(whoami): " PASSWD
+            ;;
+    esac
+
+}
+
+# Update system packages
+function updateSystemPackages () {
+
+    #TODO: Implement updateSystemPackages
+
+    printq "Updating system packages"
+
+    case $DIST in
+
+        Debian)
+            :
+            ;;
+
+        Arch)
+            :
+            ;;
+
+        Fedora)
+            :
+            ;;
+    esac
+
+}      
+
 # Install dependencies based on distro
 function installDependencies () {
 
@@ -46,6 +91,12 @@ function installDependencies () {
     # Identify the distro if it is undefined
     if [[ -z $DIST ]]; then
         whichOperatingSystem
+    fi
+
+    # Cache root passwd for the entirety of the installation
+    # NOTE: Arch does not make u
+    if [[ -z $PASSWD ]]; then
+        getPassword 
     fi
 
     echo "Installing $*"

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -21,9 +21,9 @@ function whichOperatingSystem {
         elif [[ -f /etc/arch-release ]]; then
             DIST="Arch"
 
-	# Fedora
+	    # Fedora
         elif [[ -f /etc/fedora-release ]]; then
-	    DIST="Fedora"
+	        DIST="Fedora"
 
         # Other
         else
@@ -55,7 +55,7 @@ function installDependencies () {
 
     Debian)
         # Install dependencies on a Debian host system
-        sudo apt install -y "$@"
+        read -s $PASSWD || sudo -S apt install -y "$@"
         ;;
 
     Arch)
@@ -119,7 +119,7 @@ function installDependencies () {
             if [[ -z "$var" ]]; then
                 :
             else
-                sudo dnf install $var --assumeyes
+                read -s $PASSWD || sudo -S dnf install $var --assumeyes
             fi
         done
         ;;


### PR DESCRIPTION
### Status
- [ ] Ready

### Issue
RE #130 

### Summary
Password prompts throughout the installation can be a hassle and in the case of Arch-based distros, time out the shell script entirely. This branch caches the users root password prior to running the script, and then uses it throughout the script until complete.

### Tasks
- [x] Cache and use root passwd(distro-dependent)
- [x] Integrate directly into `system.sh`
- [ ] Fix Arch issues
- [ ] Password validity check
- [ ] Test