### PR TITLE
KEYMAP for FEATURES

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,9 +99,10 @@ Due to licensing restraints, you cannot just download an ISO of Breath and flash
 > * You can replace `ubuntu` with `arch` (you can only use `cli`) or `debian` (all desktops are supported)
 > * Ubuntu supports custom versions. If you want to install Ubuntu 21.10 instead of the default Ubuntu 21.04, just run: `bash setup.sh cli ubuntu impish-21.10`, where `impish` is the codename and `21.10` is the version.
 > * You can remove the `FEATURES=ISO` to use the classic way which directly writes to a USB.
+> * You can add `KEYMAP` to `FEATURES` to map the keys to Chromebook actions; e.g., `FEATURES=ISO,KEYMAP`.
 
 3. Done! Flash the IMG file to a USB using something like Etcher.
-4. [**OPTIONAL**] Resize the partition of your USB by running `bash expand.sh`. This will expand your USB image to use the entire available space.
+4. [**RECOMMENDED**] Resize the partition of your USB by running `bash expand.sh`. This will expand your USB image to use the entire available space.
 5. Now just boot into ChromeOS, enter the shell (<kbd>CTRL</kbd> <kbd>ALT</kbd> <kbd>T</kbd>, `shell`), and run:  
 `sudo crossystem dev_boot_usb=1; sudo crossystem dev_boot_signed_only=0; sync`
 to enable USB and Custom Kernel Booting.
@@ -115,7 +116,7 @@ NetworkManager is installed by default on all distros. You can connect to the Wi
 Once booted into Breath run the command depending on your device's board:
 
 1. Connect to Wifi on your Chromebook! You can use a GUI for this or `nmcli`/`nmtui`
-   
+
 2. - `NAMI`:
      1. `VERSION=ALT bash updatekernel.sh` on the PC you built Breath with
      2. `setup-audio` on your Chromebook that has booted Breath

--- a/setup.sh
+++ b/setup.sh
@@ -85,7 +85,7 @@ if [[ $FEATURES == *"ISO"* ]]; then
    export USB=$(sudo losetup -f --show breath.img)
    export USB1="${USB}p1"
    export USB2="${USB}p2"
-  
+
 else
 
    # Wait for a USB to be plugged in
@@ -155,6 +155,18 @@ cd $ORIGINAL_DIR
 sudo chmod 755 bin/*
 sudo cp bin/* ${MNT}/usr/local/bin
 syncStorage
+
+if [[ $FEATURES == *"KEYMAP"* ]]; then
+  # Set keymap
+  # Backup the default keymap and copy in the new map
+  sudo cp -n ${MNT}/usr/share/X11/xkb/symbols/pc ${MNT}/usr/share/X11/xkb/symbols/pc.org
+  sudo cp xkb/xkb.chromebook ${MNT}/usr/share/X11/xkb/symbols/pc
+
+  # Make the Search key a Caps_Lock key
+  # Backup the default event definitions and copy in the new one
+  sudo cp -n ${MNT}/usr/share/X11/xkb/keycodes/evdev ${MNT}/usr/share/X11/xkb/keycodes/evdev.org
+  sudo cp xkb/evdev.chromebook ${MNT}/usr/share/X11/xkb/keycodes/evdev
+fi
 
 sudo umount $MNT
 

--- a/xkb/evdev.chromebook
+++ b/xkb/evdev.chromebook
@@ -1,0 +1,316 @@
+// translation from evdev scancodes to something resembling xfree86 keycodes.
+
+default xkb_keycodes "evdev" {
+	minimum = 8;
+	maximum = 255;
+
+        # Added for pc105 compatibility
+        <LSGT> = 94;
+
+	<TLDE> = 49;
+	<AE01> = 10;
+	<AE02> = 11;
+	<AE03> = 12;
+	<AE04> = 13;
+	<AE05> = 14;
+	<AE06> = 15;
+	<AE07> = 16;
+	<AE08> = 17;
+	<AE09> = 18;
+	<AE10> = 19;
+	<AE11> = 20;
+	<AE12> = 21;
+	<BKSP> = 22;
+
+	<TAB> = 23;
+	<AD01> = 24;
+	<AD02> = 25;
+	<AD03> = 26;
+	<AD04> = 27;
+	<AD05> = 28;
+	<AD06> = 29;
+	<AD07> = 30;
+	<AD08> = 31;
+	<AD09> = 32;
+	<AD10> = 33;
+	<AD11> = 34;
+	<AD12> = 35;
+	<BKSL> = 51;
+	alias <AC12> = <BKSL>;
+	<RTRN> = 36;
+
+	<AC01> = 38;
+	<AC02> = 39;
+	<AC03> = 40;
+	<AC04> = 41;
+	<AC05> = 42;
+	<AC06> = 43;
+	<AC07> = 44;
+	<AC08> = 45;
+	<AC09> = 46;
+	<AC10> = 47;
+	<AC11> = 48;
+
+	<LFSH> = 50;
+	<AB01> = 52;
+	<AB02> = 53;
+	<AB03> = 54;
+	<AB04> = 55;
+	<AB05> = 56;
+	<AB06> = 57;
+	<AB07> = 58;
+	<AB08> = 59;
+	<AB09> = 60;
+	<AB10> = 61;
+	<RTSH> = 62;
+
+	<LALT> = 64;
+	<LCTL> = 37;
+	<SPCE> = 65;
+	<RCTL> = 105;
+	<RALT> = 108;
+	// Microsoft keyboard extra keys
+        // Replace <LWIN> with <CAPS> for Chromebook
+	<CAPS> = 133;
+	<RWIN> = 134;
+	<COMP> = 135;
+	alias <MENU> = <COMP>;
+
+	<ESC> = 9;
+	<FK01> = 67;
+	<FK02> = 68;
+	<FK03> = 69;
+	<FK04> = 70;
+	<FK05> = 71;
+	<FK06> = 72;
+	<FK07> = 73;
+	<FK08> = 74;
+	<FK09> = 75;
+	<FK10> = 76;
+	<FK11> = 95;
+	<FK12> = 96;
+
+	<PRSC> = 107;
+	// <SYRQ> = 107;
+	<SCLK> = 78;
+	<PAUS> = 127;
+	// <BRK> = 419;
+
+	<INS> = 118;
+	<HOME> = 110;
+	<PGUP> = 112;
+	<DELE> = 119;
+	<END> = 115;
+	<PGDN> = 117;
+
+	<UP> = 111;
+	<LEFT> = 113;
+	<DOWN> = 116;
+	<RGHT> = 114;
+
+	<NMLK> = 77;
+	<KPDV> = 106;
+	<KPMU> = 63;
+	<KPSU> = 82;
+
+	<KP7> = 79;
+	<KP8> = 80;
+	<KP9> = 81;
+	<KPAD> = 86;
+
+	<KP4> = 83;
+	<KP5> = 84;
+	<KP6> = 85;
+
+	<KP1> = 87;
+	<KP2> = 88;
+	<KP3> = 89;
+	<KPEN> = 104;
+
+	<KP0> = 90;
+	<KPDL> = 91;
+	<KPEQ> = 125;
+
+	<FK13> = 191;
+	<FK14> = 192;
+	<FK15> = 193;
+	<FK16> = 194;
+	<FK17> = 195;
+	<FK18> = 196;
+	<FK19> = 197;
+	<FK20> = 198;
+	<FK21> = 199;
+	<FK22> = 200;
+	<FK23> = 201;
+	<FK24> = 202;
+
+	// Keys that are generated on Japanese keyboards
+
+	//<HZTG> =  93;	// Hankaku/Zenkakau toggle - not actually used
+	alias <HZTG> = <TLDE>;
+	<HKTG> = 101;	// Hiragana/Katakana toggle
+	<AB11> = 97;	// backslash/underscore
+	<HENK> = 100;	// Henkan
+	<MUHE> = 102;	// Muhenkan
+	<AE13> = 132;	// Yen
+	<KATA> =  98;	// Katakana
+	<HIRA> =  99;	// Hiragana
+	<JPCM> = 103;	// KPJPComma
+	//<RO>   =  97;	// Romaji
+
+	// Keys that are generated on Korean keyboards
+
+	<HNGL> = 130;	// Hangul Latin toggle
+	<HJCV> = 131;	// Hangul to Hanja conversion
+
+	// Solaris compatibility
+
+	alias <LMTA> = <LWIN>;
+	alias <RMTA> = <RWIN>;
+	<MUTE> = 121;
+	<VOL-> = 122;
+	<VOL+> = 123;
+	<POWR> = 124;
+	<STOP> = 136;
+	<AGAI> = 137;
+	<PROP> = 138;
+	<UNDO> = 139;
+	<FRNT> = 140;
+	<COPY> = 141;
+	<OPEN> = 142;
+	<PAST> = 143;
+	<FIND> = 144;
+	<CUT>  = 145;
+	<HELP> = 146;
+
+	// Extended keys that may be generated on "Internet" keyboards.
+	// evdev has standardize names for these.
+
+	<LNFD> = 109;	// #define KEY_LINEFEED            101
+	<I120> = 120;	// #define KEY_MACRO               112
+	<I126> = 126;	// #define KEY_KPPLUSMINUS         118
+	<I128> = 128;   // #define KEY_SCALE               120
+	<I129> = 129;	// #define KEY_KPCOMMA             121
+	<I147> = 147;	// #define KEY_MENU                139
+	<I148> = 148;	// #define KEY_CALC                140
+	<I149> = 149;	// #define KEY_SETUP               141
+	<I150> = 150;	// #define KEY_SLEEP               142
+	<I151> = 151;	// #define KEY_WAKEUP              143
+	<I152> = 152;	// #define KEY_FILE                144
+	<I153> = 153;	// #define KEY_SENDFILE            145
+	<I154> = 154;	// #define KEY_DELETEFILE          146
+	<I155> = 155;	// #define KEY_XFER                147
+	<I156> = 156;	// #define KEY_PROG1               148
+	<I157> = 157;	// #define KEY_PROG2               149
+	<I158> = 158;	// #define KEY_WWW                 150
+	<I159> = 159;	// #define KEY_MSDOS               151
+	<I160> = 160;	// #define KEY_COFFEE              152
+	<I161> = 161;	// #define KEY_DIRECTION           153
+	<I162> = 162;	// #define KEY_CYCLEWINDOWS        154
+	<I163> = 163;	// #define KEY_MAIL                155
+	<I164> = 164;	// #define KEY_BOOKMARKS           156
+	<I165> = 165;	// #define KEY_COMPUTER            157
+	<I166> = 166;	// #define KEY_BACK                158
+	<I167> = 167;	// #define KEY_FORWARD             159
+	<I168> = 168;	// #define KEY_CLOSECD             160
+	<I169> = 169;	// #define KEY_EJECTCD             161
+	<I170> = 170;	// #define KEY_EJECTCLOSECD        162
+	<I171> = 171;	// #define KEY_NEXTSONG            163
+	<I172> = 172;	// #define KEY_PLAYPAUSE           164
+	<I173> = 173;	// #define KEY_PREVIOUSSONG        165
+	<I174> = 174;	// #define KEY_STOPCD              166
+	<I175> = 175;	// #define KEY_RECORD              167
+	<I176> = 176;	// #define KEY_REWIND              168
+	<I177> = 177;	// #define KEY_PHONE               169
+	<I178> = 178;	// #define KEY_ISO                 170
+	<I179> = 179;	// #define KEY_CONFIG              171
+	<I180> = 180;	// #define KEY_HOMEPAGE            172
+	<I181> = 181;	// #define KEY_REFRESH             173
+	<I182> = 182;	// #define KEY_EXIT                174
+	<I183> = 183;	// #define KEY_MOVE                175
+	<I184> = 184;	// #define KEY_EDIT                176
+	<I185> = 185;	// #define KEY_SCROLLUP            177
+	<I186> = 186;	// #define KEY_SCROLLDOWN          178
+	<I187> = 187;	// #define KEY_KPLEFTPAREN         179
+	<I188> = 188;	// #define KEY_KPRIGHTPAREN        180
+	<I189> = 189;	// #define KEY_NEW                 181
+	<I190> = 190;	// #define KEY_REDO                182
+	<I208> = 208;	// #define KEY_PLAYCD              200
+	<I209> = 209;	// #define KEY_PAUSECD             201
+	<I210> = 210;	// #define KEY_PROG3               202
+	<I211> = 211;	// #define KEY_PROG4               203 conflicts with AB11
+	<I212> = 212;   // #define KEY_DASHBOARD           204
+	<I213> = 213;	// #define KEY_SUSPEND             205
+	<I214> = 214;	// #define KEY_CLOSE               206
+	<I215> = 215;	// #define KEY_PLAY                207
+	<I216> = 216;	// #define KEY_FASTFORWARD         208
+	<I217> = 217;	// #define KEY_BASSBOOST           209
+	<I218> = 218;	// #define KEY_PRINT               210
+	<I219> = 219;	// #define KEY_HP                  211
+	<I220> = 220;	// #define KEY_CAMERA              212
+	<I221> = 221;	// #define KEY_SOUND               213
+	<I222> = 222;	// #define KEY_QUESTION            214
+	<I223> = 223;	// #define KEY_EMAIL               215
+	<I224> = 224;	// #define KEY_CHAT                216
+	<I225> = 225;	// #define KEY_SEARCH              217
+	<I226> = 226;	// #define KEY_CONNECT             218
+	<I227> = 227;	// #define KEY_FINANCE             219
+	<I228> = 228;	// #define KEY_SPORT               220
+	<I229> = 229;	// #define KEY_SHOP                221
+	<I230> = 230;	// #define KEY_ALTERASE            222
+	<I231> = 231;	// #define KEY_CANCEL              223
+	<I232> = 232;	// #define KEY_BRIGHTNESSDOWN      224
+	<I233> = 233;	// #define KEY_BRIGHTNESSUP        225
+	<I234> = 234;	// #define KEY_MEDIA               226
+	<I235> = 235;	// #define KEY_SWITCHVIDEOMODE     227
+	<I236> = 236;	// #define KEY_KBDILLUMTOGGLE      228
+	<I237> = 237;	// #define KEY_KBDILLUMDOWN        229
+	<I238> = 238;	// #define KEY_KBDILLUMUP          230
+	<I239> = 239;	// #define KEY_SEND                231
+	<I240> = 240;	// #define KEY_REPLY               232
+	<I241> = 241;	// #define KEY_FORWARDMAIL         233
+	<I242> = 242;	// #define KEY_SAVE                234
+	<I243> = 243;	// #define KEY_DOCUMENTS           235
+	<I244> = 244;	// #define KEY_BATTERY             236
+	<I245> = 245;	// #define KEY_BLUETOOTH           237
+	<I246> = 246;	// #define KEY_WLAN                238
+	<I247> = 247;	// #define KEY_UWB                 239
+	<I248> = 248;	// #define KEY_UNKNOWN             240
+	<I249> = 249;	// #define KEY_VIDEO_NEXT          241
+	<I250> = 250;	// #define KEY_VIDEO_PREV          242
+	<I251> = 251;	// #define KEY_BRIGHTNESS_CYCLE    243
+	<I252> = 252;	// #define KEY_BRIGHTNESS_ZERO     244
+	<I253> = 253;	// #define KEY_DISPLAY_OFF         245
+	<I254> = 254;	// #define KEY_WWAN                246
+	<I255> = 255;	// #define KEY_RFKILL              247
+
+	<I372> = 372;   // #define KEY_FAVORITES           364
+	<I382> = 382;   // #define KEY_KEYBOARD            374
+	<I569> = 569;   // #define KEY_ROTATE_LOCK_TOGGLE  561
+	<I380> = 380;   // #define KEY_FULL_SCREEN         372
+
+	// Fake keycodes for virtual keys
+	<LVL3> =   92;
+	<MDSW> =   203;
+	<ALT>  =   204;
+	<META> =   205;
+	<SUPR> =   206;
+	<HYPR> =   207;
+
+	indicator 1  = "Caps Lock";
+	indicator 2  = "Num Lock";
+	indicator 3  = "Scroll Lock";
+	indicator 4  = "Compose";
+	indicator 5  = "Kana";
+	indicator 6  = "Sleep";
+	indicator 7  = "Suspend";
+	indicator 8  = "Mute";
+	indicator 9  = "Misc";
+	indicator 10 = "Mail";
+	indicator 11 = "Charging";
+
+	alias <ALGR> = <RALT>;
+
+	// For Brazilian ABNT2
+	alias <KPPT> = <I129>;
+};

--- a/xkb/xkb.chromebook
+++ b/xkb/xkb.chromebook
@@ -1,0 +1,103 @@
+default  partial alphanumeric_keys modifier_keys
+xkb_symbols "pc105" {
+
+    key <ESC>  {	[ Escape		]	};
+
+    // The extra key on many European keyboards:
+    key <LSGT> {	[ less, greater, bar, brokenbar ] };
+
+    // The following keys are common to all layouts.
+    key <BKSL> {	[ backslash,	bar	]	};
+    key <SPCE> {	[ 	 space		]	};
+
+    include "srvr_ctrl(fkey2vt)"
+    include "pc(editing)"
+    include "keypad(x11)"
+
+    key <BKSP> {	[ BackSpace, Delete	]	};
+
+    key  <TAB> {	[ Tab,	ISO_Left_Tab	]	};
+    key <RTRN> {	[ Return		]	};
+
+    key <CAPS> {	[ Caps_Lock		]	};
+    key <NMLK> {	[ Num_Lock 		]	};
+
+    key <LFSH> {	[ Shift_L		]	};
+    key <LCTL> {	[ Control_L		]	};
+    key <LWIN> {	[ Super_L		]	};
+
+    key <RTSH> {	[ Shift_R		]	};
+    key <RCTL> {	[ Control_R		]	};
+    key <RWIN> {	[ Super_R		]	};
+    key <MENU> {	[ Menu			]	};
+
+    // Beginning of modifier mappings.
+    modifier_map Shift  { Shift_L, Shift_R };
+    modifier_map Lock   { Caps_Lock };
+    modifier_map Control{ Control_L, Control_R };
+    modifier_map Mod2   { Num_Lock };
+    modifier_map Mod4   { Super_L, Super_R };
+
+    // Fake keys for virtual<->real modifiers mapping:
+    key <LVL3> {	[ ISO_Level3_Shift	]	};
+    key <MDSW> {	[ Mode_switch 		]	};
+    modifier_map Mod5   { <LVL3>, <MDSW> };
+
+    key <ALT>  {	[ NoSymbol, Alt_L	]	};
+    include "altwin(meta_alt)"
+
+    key <META> {	[ NoSymbol, Meta_L	]	};
+    modifier_map Mod1   { <META> };
+
+    key <SUPR> {	[ NoSymbol, Super_L	]	};
+    modifier_map Mod4   { <SUPR> };
+
+    key <HYPR> {	[ NoSymbol, Hyper_L	]	};
+    modifier_map Mod4   { <HYPR> };
+    // End of modifier mappings.
+
+    key <OUTP> { [ XF86Display ] };
+    key <KITG> { [ XF86KbdLightOnOff ] };
+    key <KIDN> { [ XF86KbdBrightnessDown ] };
+    key <KIUP> { [ XF86KbdBrightnessUp ] };
+	
+};
+
+hidden partial alphanumeric_keys
+xkb_symbols "editing" {
+    key <PRSC> {
+	type= "PC_ALT_LEVEL2",
+	symbols[Group1]= [ Print, Sys_Req ]
+    };
+    key <SCLK> {	[  Scroll_Lock		]	};
+    key <PAUS> {
+	type= "PC_CONTROL_LEVEL2",
+	symbols[Group1]= [ Pause, Break ]
+    };
+    key  <INS> {	[  Insert		]	};
+    key <HOME> {	[  Home			]	};
+    key <PGUP> {	[  Prior		]	};
+    key <DELE> {	[  Delete		]	};
+    key  <END> {	[  End			]	};
+    key <PGDN> {	[  Next			]	};
+
+    // added for ChromeBook
+    key <FK01> { 	[XF86Back, NoSymbol, NoSymbol, NoSymbol, F1] 			};
+    key <FK02> { 	[XF86Forward, NoSymbol, NoSymbol, NoSymbol, F2] 		};
+    key <FK03> { 	[XF86Refresh, NoSymbol, NoSymbol, NoSymbol, F3] 		};
+    key <FK04> { 	[Print, NoSymbol, NoSymbol, NoSymbol, F4] 			};
+    key <FK05> { 	[Super_L, NoSymbol, NoSymbol, NoSymbol, F5] 			};
+    key <FK06> { 	[XF86MonBrightnessDown, NoSymbol, NoSymbol, NoSymbol, F6] 	};
+    key <FK07> { 	[XF86MonBrightnessUp, NoSymbol, NoSymbol, NoSymbol, F7] 	};
+    key <FK08> { 	[XF86AudioMute, NoSymbol, NoSymbol, NoSymbol, F8] 		};
+    key <FK09> { 	[XF86AudioLowerVolume, NoSymbol, NoSymbol, NoSymbol, F9] 	};
+    key <FK10> { 	[XF86AudioRaiseVolume, NoSymbol, NoSymbol, NoSymbol, F10] 	};
+    key <LWIN> { 	[Caps_Lock] };
+
+    // added for ChromeBook
+    key <UP>   {	[  Up		]	};
+    key <LEFT> {	[  Left		]	};
+    key <DOWN> {	[  Down		]	};
+    key <RGHT> {	[  Right	]	};
+		
+};


### PR DESCRIPTION
Added code to support specifying to map keys to Chromebook standard; e.g., FEATURES=ISO,KEYMAP.  Also, updated docs page to include a line with instructions.  Without this specification, the build occurs as normal; i.e., no key mapping.