### PR TITLE
Arch version of install-to-internal-storage

### DIFF
--- a/bin/install-to-internal-storage
+++ b/bin/install-to-internal-storage
@@ -12,8 +12,8 @@ if [[ -f "/etc/arch-version" ]] || [[ -f "/etc/arch-release" ]]; then
     cd ./flashrom-git  && makepkg -cis 
     cd ../trousers     && makepkg -cis
     cd ../vboot-utils  && makepkg -cis 
-
-    pacman -Syu rsync curl
+   
+    sudo pacman -Syu rsync curl parted
 
     cd ../
     rm -rf ./flashrom-git ./trousers ./vboot-utils


### PR DESCRIPTION
Fixed two issues with arch install version of install-to-internal-storage regarding an issue with pacman not having root privilege and parted not being installed.