### PR TITLE
Allow use of kernel generated from build.sh

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,7 @@ Due to licensing restraints, you cannot just download an ISO of Breath and flash
 > * Ubuntu supports custom versions. If you want to install Ubuntu 21.10 instead of the default Ubuntu 21.04, just run: `bash setup.sh cli ubuntu impish-21.10`, where `impish` is the codename and `21.10` is the version.
 > * You can remove the `FEATURES=ISO` to use the classic way which directly writes to a USB.
 > * You can add `KEYMAP` to `FEATURES` to map the keys to Chromebook actions; e.g., `FEATURES=ISO,KEYMAP`.
+> * You can add `LOCAL_KERNEL` to instruct it to use a local kernel generated from `build.sh`; e.g., `FEATURES=ISO,LOCAL_KERNEL`.
 
 3. Done! Flash the IMG file to a USB using something like Etcher.
 4. [**RECOMMENDED**] Resize the partition of your USB by running `bash expand.sh`. This will expand your USB image to use the entire available space.

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ export DESKTOP=$1
 export DISTRO=$2
 export DISTRO_VERSION=$3
 export MNT="/mnt"
-ORIGINAL_DIR=$(pwd)
+export ORIGINAL_DIR=$(pwd)
 
 # Crostini already has folders in /mnt
 if [[ $FEATURES == *"CROSTINI"* ]]; then

--- a/utils/bootstrap.sh
+++ b/utils/bootstrap.sh
@@ -17,13 +17,20 @@ function bootstrapFiles {
   printq "Installing Dependencies"
   installDependencies vboot-kernel-utils arch-install-scripts git wget cgpt $FW_PACKAGE
 
-
+if [[ $FEATURES == *"LOCAL_KERNEL"* ]]; then
+  cp $ORIGINAL_DIR/kernel/bzImage .
+  cp $ORIGINAL_DIR/kernel/modules.tar.xz .
+  cp $ORIGINAL_DIR/kernel/kernel.flags .
+  printq "Copied kernel files from breath/kernel"
+else
+  printq "Downloading kernel files from cb-lines/breath"
   # Download the kernel bzImage and the kernel modules (wget)
   {
   wget https://github.com/cb-linux/breath/releases/latest/download/bzImage -O bzImage -q --show-progress
   wget https://github.com/cb-linux/breath/releases/latest/download/modules.tar.xz -O modules.tar.xz -q --show-progress
   wget https://raw.githubusercontent.com/cb-linux/kernel/main/kernel.flags -O kernel.flags -q --show-progress
   } || true # Wget has the wrong exit status with no clobber
+fi
 
   # READ: Distro dependent step
   # Download the root file system based on the distribution


### PR DESCRIPTION
bootstrapFiles was always downloading the kernel from cb-linux.  This change adds the feature `LOCAL_KERNEL` to specify using the kernel generated from `build.sh.`