### PR TITLE
Alter to support build of 22.04 LTS

### DIFF
--- a/bin/apl-sof-setup-audio
+++ b/bin/apl-sof-setup-audio
@@ -5,6 +5,7 @@ set -e
 
 [[ -n "$1" ]] && { export DIR=$1; }
 
+sudo add-apt-repository restricted
 sudo apt install vboot-kernel-utils cgpt gzip -y
 sudo apt install -y firmware-sof-signed || sudo apt-get -o Dpkg::Options::="--force-overwrite" install firmware-sof-signed
 

--- a/utils/bootstrap.sh
+++ b/utils/bootstrap.sh
@@ -39,7 +39,8 @@ fi
   ubuntu)
       # Split up the distro version
       # Argument 3 / DISTRO_VERSION should be something like focal-20.04
-      [[ -n $DISTRO_VERSION ]] || { printerr "No Ubuntu version specified, using hirsute-21.04"; export DISTRO_VERSION=hirsute-21.04; }
+      DEFAULT_VERSION="jammy-22.04"
+      [[ -n $DISTRO_VERSION ]] || { printerr "No Ubuntu version specified, using ${DEFAULT_VERSION}"; export DISTRO_VERSION=$DEFAULT_VERSION; }
       export DISTRO_CODENAME=$(echo "$DISTRO_VERSION" | cut -d- -f1) # e.g. hirsute
       export DISTRO_RELEASE=$(echo "$DISTRO_VERSION" | cut -d- -f2)  # e.g. 21.04
 

--- a/utils/bootstrap.sh
+++ b/utils/bootstrap.sh
@@ -39,10 +39,17 @@ fi
   ubuntu)
       # Split up the distro version
       # Argument 3 / DISTRO_VERSION should be something like focal-20.04
-      DEFAULT_VERSION="jammy-22.04"
-      [[ -n $DISTRO_VERSION ]] || { printerr "No Ubuntu version specified, using ${DEFAULT_VERSION}"; export DISTRO_VERSION=$DEFAULT_VERSION; }
-      export DISTRO_CODENAME=$(echo "$DISTRO_VERSION" | cut -d- -f1) # e.g. hirsute
-      export DISTRO_RELEASE=$(echo "$DISTRO_VERSION" | cut -d- -f2)  # e.g. 21.04
+      if [[ -n $DISTRO_VERSION ]]; then
+        export DISTRO_CODENAME=$(echo "$DISTRO_VERSION" | cut -d- -f1) # e.g. hirsute
+        export DISTRO_RELEASE=$(echo "$DISTRO_VERSION" | cut -d- -f2)  # e.g. 21.04
+        printq "Using ${DISTRO_CODENAME}-${DISTRO_RELEASE}"
+      else
+        # This assumes the build system is also Ubuntu
+        LATEST=$(tail -n 1 /usr/share/distro-info/ubuntu.csv)
+        export DISTRO_RELEASE=$(echo $LATEST | cut -d, -f1 | cut -d' ' -f1)
+        export DISTRO_CODENAME=$(echo $LATEST | cut -d, -f3)
+        printerr "No Ubuntu version specified, using ${DISTRO_CODENAME}-${DISTRO_RELEASE}"
+      fi
 
       # Download the Ubuntu rootfs if it doesn't exist
       DISTRO_ROOTFS="ubuntu-rootfs.tar.xz"

--- a/utils/distros/ubuntu.sh
+++ b/utils/distros/ubuntu.sh
@@ -56,7 +56,7 @@ EOT
       gnome)
         export DESKTOP_PACKAGE="apt install -y ubuntu-desktop"
         ;;
-      
+
       deepin)
         export DESKTOP_PACKAGE="add-apt-repository ppa:ubuntudde-dev/stable; apt update; apt install -y ubuntudde-dde"
         ;;
@@ -115,7 +115,13 @@ EOT
 
     # Fix for GDM3
     # https://askubuntu.com/questions/1239503/ubuntu-20-04-and-20-10-etc-securetty-no-such-file-or-directory
-    sudo cp ${MNT}/usr/share/doc/util-linux/examples/securetty ${MNT}/etc/securetty
+    SURETTY=${MNT}/usr/share/doc/util-linux/examples/securetty
+    if [ -f "$SURETTY" ]; then
+      printq "Copying securetty"
+      sudo cp ${SURETTY} ${MNT}/etc/securetty
+    else
+      printq "Did not find securetty"
+    fi
 
     # Only create a new user and add it to the sudo group if the user doesn't already exist
     if runChrootCommand "id $BREATH_USER"; then


### PR DESCRIPTION
22.04 LTS jammy was released 04/21/22.  This corrects the default version in `bootstrap.sh` to select the latest available distro, adjusts `ubuntu.sh` to skip the copy of `securetty` if the example file is not found, and adds the restricted repo since the SOF firmware was moved to that repo.