### PR TITLE
Improve installation speed during development by skipping previously installed packages.

### DIFF
--- a/utils/system.sh
+++ b/utils/system.sh
@@ -44,23 +44,12 @@ function checkDependency() {
     
     # NOTE: Distro dependent step
     # NOTE: Debian handles this faster via apt.
+    # NOTE: Fedora handles this faster via dnf.
 
     case $DIST in
         
     Arch)
         if ! command -v pacman -Qi $1 &> /dev/null
-        then
-            printq "Installing $1..."
-            return 1 # Package not present on system
-        else
-            printq "$1 already installed, skipping..."
-            return 0 # Package present on system
-        fi
-        ;;
-
-    # UNTESTED!
-    Fedora)
-        if ! command -v dnf list installed $1 &> /dev/null
         then
             printq "Installing $1..."
             return 1 # Package not present on system
@@ -142,22 +131,17 @@ function installDependencies () {
 
                 # vboot-utils
                 vboot-kernel-utils)
-                    if checkDependency vboot-utils; then var=""; else var=vboot-utils; fi
+                    var=vboot-utils;
                     ;;
 
                 # growpart
                 cloud-guest-utils)
-                    if checkDependency cloud-utils-growpart; then var=""; else var=cloud-utils-growpart; fi
+                    var=cloud-utils-growpart;
                     ;;
 
                 # cgpt
                 cgpt)
                     unset var; # Included in vboot-utils
-                    ;;
-
-                # Skip any packages already installed that weren't accounted for
-                *)
-                    if checkDependency $var; then var=""; else var=$var; fi
                     ;;
         
             esac

--- a/utils/system.sh
+++ b/utils/system.sh
@@ -43,20 +43,9 @@ function whichOperatingSystem {
 function checkDependency() {
     
     # NOTE: Distro dependent step
+    # NOTE: Debian handles this faster via apt.
 
     case $DIST in
-
-    # UNTESTED!
-    Debian)
-        if ! command -v dpkg -s $1 &> /dev/null
-        then
-            printq "Installing $1..."
-            return 1 # Package not present on system
-        else
-            printq "$1 already installed, skipping..."
-            return 0 # Package present on system
-        fi
-        ;;
         
     Arch)
         if ! command -v pacman -Qi $1 &> /dev/null
@@ -102,11 +91,7 @@ function installDependencies () {
 
     Debian)
         # Install dependencies on a Debian host system
-        for var in "$@"
-        do
-            if checkDependency $var; then var=""; else var=$var; fi
-            sudo apt install -y $var
-        done
+        sudo apt install -y "$@"
         ;;
 
     Arch)


### PR DESCRIPTION
Exactly as the title suggests, the `checkDependency` function checks to see whether a package is installed on the system or not, skipping if that is the case. Arch support included out of box, will test debian and fedora asap :)