### PR TITLE
[enh] Remove uncessary output

### DIFF
--- a/bin/updatekernel-on-emmc
+++ b/bin/updatekernel-on-emmc
@@ -54,7 +54,7 @@ else
   export USB_KERNEL="${USB}p1"
 fi
 
-cd ~/linux-build || { mkdir ~/linux-build; cd ~/linux-build; }
+cd ~/linux-build &>/dev/null || { mkdir ~/linux-build; cd ~/linux-build; }
 
 # Download kernel commandline
 bash <(curl -s https://raw.githubusercontent.com/cb-linux/breath/main/kernel.root.flags.sh) > kernel.flags


### PR DESCRIPTION
Hello, this is a pull request for "Removing the false-negative message because we are creating the folder 'linux-build' anyway".