### PR TITLE
Enhanced Fedora support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,8 +107,9 @@ Due to licensing restraints, you cannot just download an ISO of Breath and flash
 
 > * You must add `CROSTINI` to `FEATURES` (so `FEATURES=ISO,KEYMAP,CROSTINI`)  if you're running this script from Crostini.
 > * **Using the CLI argument installs a minimal CLI (no desktop!) environment on the USB.** If you would like to install a desktop, you can use `gnome`, `kde`, `minimal`, `deepin`, `budgie`, `xfce`, `lxqt`, `mate` or `openbox` instead of `cli`.
-> * You can replace `ubuntu` with `arch` (you can only use `cli`) or `debian` (all desktops are supported)
+> * You can replace `ubuntu` with `arch`, `fedora` (you can only use `cli`) or `debian` (all desktops are supported)
 > * Ubuntu supports custom versions. If you want to install Ubuntu 21.10 instead of the default Ubuntu 22.04, just run: `bash setup.sh cli ubuntu impish-21.10`, where `impish` is the codename and `21.10` is the version.
+> * Fedora also supports custom versions. Just add the desired version number at the end of `setup.sh` command: `bash setup.sh cli fedora 36`.
 > * You can remove the `FEATURES=ISO` to use the classic way which directly writes to a USB.
 
 1. Done! Flash the IMG file to a USB using something like Etcher.

--- a/utils/bootstrap.sh
+++ b/utils/bootstrap.sh
@@ -67,11 +67,23 @@ fi
   fedora)
       # Download the Fedora rootfs if it doesn't exist
       # Extracting a Fedora rootfs from koji is quite complicated
-      # I've hardcoded it, but otherwise you need to parse a json file
-      # TOOD: Implement versioning support in Fedora
+      # Since they don't provide a latest symlink we need to figure it out based on current date
+      # Generate yesterday date to fetch the good enough update image from koji
+      YESTERDAY=`TZ=aaa24 date +%Y%m%d`
+
       DISTRO_ROOTFS="fedora-rootfs.tar.xz"
+
+      # Check and set Fedora version to be used
+      if [[ -n $DISTRO_VERSION ]]; then
+        export DISTRO_RELEASE=$(echo "$DISTRO_VERSION")
+        printq "Using Fedora ${DISTRO_RELEASE}"
+      else
+        export DISTRO_RELEASE="36"
+        printerr "No Fedora version specified, using Fedora ${DISTRO_RELEASE}"
+      fi
+
       [[ ! -f $DISTRO_ROOTFS ]] && {
-      wget "https://kojipkgs.fedoraproject.org//packages/Fedora-Container-Base/35/20211127.0/images/Fedora-Container-Base-35-20211127.0.x86_64.tar.xz" -O $DISTRO_ROOTFS -q --show-progress
+      wget https://kojipkgs.fedoraproject.org/packages/Fedora-Container-Base/${DISTRO_RELEASE}/${YESTERDAY}.0/images/Fedora-Container-Base-${DISTRO_RELEASE}-${YESTERDAY}.0.x86_64.tar.xz -O $DISTRO_ROOTFS -q --show-progress
       }
       ;;
 

--- a/utils/distros/fedora.sh
+++ b/utils/distros/fedora.sh
@@ -56,7 +56,7 @@ function postinstall {
     esac
 
     # Install nonfree repos
-    sudo chroot $MNT /bin/bash -c "sudo dnf install https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm -y"
+    sudo chroot $MNT /bin/bash -c "sudo dnf install https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${DISTRO_RELEASE}.noarch.rpm -y"
 
     # Disable plymouth (sometimes fails for no apparent reason)
     runChrootCommand "plymouth-set-default-theme details -R &> /dev/null" || true

--- a/utils/extract.sh
+++ b/utils/extract.sh
@@ -27,7 +27,7 @@ function extractRootfs {
 			mkdir fedora
 			sudo tar xvpf $DISTRO_ROOTFS -C fedora
 			# This will look for layer.tar file inside whatever hashed directory name was on the tar package and copy it.
-			find fedora -name layer.tar -exec echo cp {} rootfs.tar \;
+			find fedora -name layer.tar -exec cp {} rootfs.tar \;
 			DISTRO_ROOTFS_ABSOLUTE=$(readlink -f rootfs.tar)
 			cd $MNT
 			sudo tar --wildcards -xvpf "$DISTRO_ROOTFS_ABSOLUTE" "./*"

--- a/utils/extract.sh
+++ b/utils/extract.sh
@@ -26,7 +26,8 @@ function extractRootfs {
 			sudo rm -rf fedora &> /dev/null || true
 			mkdir fedora
 			sudo tar xvpf $DISTRO_ROOTFS -C fedora
-			cp fedora/6c00560306a90bf0718a9a003defbc89a0d6441b8ec719a69416eba6a06c3218/layer.tar rootfs.tar
+			# This will look for layer.tar file inside whatever hashed directory name was on the tar package and copy it.
+			find fedora -name layer.tar -exec echo cp {} rootfs.tar \;
 			DISTRO_ROOTFS_ABSOLUTE=$(readlink -f rootfs.tar)
 			cd $MNT
 			sudo tar --wildcards -xvpf "$DISTRO_ROOTFS_ABSOLUTE" "./*"


### PR DESCRIPTION
This PR fixes the creation of Fedora images since the hardcoded files are long gone, while also enhancing its support.

* Added Fedora version support.
* Removed the hardcoded hash directory to layer.tar. It will automatically discover it.
* Added a hacky way to fetch a "good enough" image from koji based on date.
* Removed the explicit `rpm` command call while setting rpmfusion repositories
* Added version support for setting up the repositories using `DISTRO_RELEASE` variable
* Improved compatibility when running inside Crostini
* Updated documentation.

Signed-off-by: Vinícius Ferrão <vinicius@ferrao.net.br>