### PR TITLE
WIP: Python integration

### DIFF
--- a/ports/python/__init__.py
+++ b/ports/python/__init__.py
@@ -1,0 +1,4 @@
+import breath
+
+if __name__ == '__main__':
+    breath.run_as_module()

--- a/ports/python/__main__.py
+++ b/ports/python/__main__.py
@@ -1,0 +1,17 @@
+#-*- encoding: utf-8 -*-
+
+"""
+Python Breath adaptation
+"""
+
+__title__ = 'breath'
+__summary__ = 'A way to natively run Linux on modern Chromebooks without replacing firmware.'
+__author__ = 'MilkyDeveloper'
+__license__ = 'MIT'
+__copyright__ = 'Copyright 2021-present MilkyDeveloper'
+__version__ = '4.2.2-feature/python-base'
+
+
+def run_as_module():
+    pass
+    


### PR DESCRIPTION
- [ ] Ready

## Summary
Adds a python-based tui. Now, I know I've tried to create a python port of breath before, but bear with me. It has already been established that python is not the best way to interact with the terminal, showcased clearly in the first attempt. But, I believe the tui was a good addition, and over the last few months I have come up with a few ideas on how a python base can help out, which I intend to fulfill in this pr. Firstly, the constant workarounds that are needed to create a headless installation. Managing the state of the installer permission level is far easier at the core process(python), allowing to let the user walk away from an install and come back to a plug and play usb/iso. Second, the ability to run breath on more than just linux. With python at the core, we can have a user set the config, and then plug in our powershell/bash scripts depending on what the user's host operating system is. And lastly, the ability to nicely package breath into the various package manager's our there. Having several PKGBUILD's would be cool. Anyways, my apologies if this pr seems a bit, well, far fetched. I think it is a good idea, but I am not the only one who uses breath. Oh, and one other cool feature down the road that would be way easier to integrate with python: flashing Mr. Chromeboxes bios automatically/etc. This would probably be best explained somehow else, but im envisioning a function that waits for the user to plug in a suzyqable, pick some options, waits for confirmation that the user has hit the various sequences(restarts, whatevers), and elegantly removes the bios. Maybe even allowing support for opencore bios options to boot macos(Im just speculating at this point) or windows. Anyways, I think it would be a nice way to wrap breath together and make it a lot more extensible with a lot less hastle. Let me know what you think @MilkyDeveloper. In the meantime I will be working on this pr :)